### PR TITLE
Add the ability to track the generated object count for requests

### DIFF
--- a/lib/rails_request_stats/report.rb
+++ b/lib/rails_request_stats/report.rb
@@ -11,21 +11,23 @@ module RailsRequestStats
     def report_text
       avg_view_runtime = "AVG view_runtime: #{format_number(avg_stat(:view_runtime))}ms"
       avg_db_runtime = "AVG db_runtime: #{format_number(avg_stat(:db_runtime))}ms"
+      avg_generated_object_count = "AVG generated_object_count: #{format_number(avg_stat(:generated_object_count))}"
       query_count = "query_count: #{format_number(last_stat(:query_count))}"
       cached_query_count = "cached_query_count: #{format_number(last_stat(:cached_query_count))}"
 
-      "[RailsRequestStats] (#{[avg_view_runtime, avg_db_runtime, query_count, cached_query_count].join(' | ')})"
+      "[RailsRequestStats] (#{[avg_view_runtime, avg_db_runtime, avg_generated_object_count, query_count, cached_query_count].join(' | ')})"
     end
 
     def exit_report_text
       controller_information = "[RailsRequestStats] #{@request_stats.action.upcase}:#{@request_stats.format} \"#{@request_stats.path}\""
       avg_view_runtime = "AVG view_runtime: #{format_number(avg_stat(:view_runtime))}ms"
       avg_db_runtime = "AVG db_runtime: #{format_number(avg_stat(:db_runtime))}ms"
+      avg_generated_object_count = "AVG generated_object_count: #{format_number(avg_stat(:generated_object_count))}"
       min_query_count = "MIN query_count: #{format_number(min_stat(:query_count))}"
       max_query_count = "MAX query_count: #{format_number(max_stat(:query_count))}"
       request_count = "from #{format_number(count_stat(:view_runtime))} requests"
 
-      "#{controller_information} (#{[avg_view_runtime, avg_db_runtime, min_query_count, max_query_count].join(' | ')}) #{request_count}"
+      "#{controller_information} (#{[avg_view_runtime, avg_db_runtime, avg_generated_object_count, min_query_count, max_query_count].join(' | ')}) #{request_count}"
     end
 
     def min_stat(category)

--- a/lib/rails_request_stats/request_stats.rb
+++ b/lib/rails_request_stats/request_stats.rb
@@ -8,7 +8,8 @@ module RailsRequestStats
                 :view_runtime_collection,
                 :db_runtime_collection,
                 :query_count_collection,
-                :cached_query_count_collection
+                :cached_query_count_collection,
+                :generated_object_count_collection
 
     def initialize(key)
       @action = key[:action]
@@ -20,13 +21,15 @@ module RailsRequestStats
       @db_runtime_collection = []
       @query_count_collection = []
       @cached_query_count_collection = []
+      @generated_object_count_collection = []
     end
 
-    def add_stats(view_runtime, db_runtime, query_count, cached_query_count)
+    def add_stats(view_runtime, db_runtime, query_count, cached_query_count, generated_object_count)
       @view_runtime_collection << view_runtime.to_f
       @db_runtime_collection << db_runtime.to_f
       @query_count_collection << query_count
       @cached_query_count_collection << cached_query_count
+      @generated_object_count_collection << generated_object_count
     end
   end
 end

--- a/spec/rails_request_stats/report_spec.rb
+++ b/spec/rails_request_stats/report_spec.rb
@@ -17,20 +17,20 @@ describe RailsRequestStats::Report do
 
   before do
     stat_values.each do |value|
-      request_stats.add_stats(value, value, value, value)
+      request_stats.add_stats(value, value, value, value, value)
     end
   end
 
   describe '#report_text' do
     it 'returns report_text of last added stats' do
-      expected_report_text = '[RailsRequestStats] (AVG view_runtime: 11.6667ms | AVG db_runtime: 11.6667ms | query_count: 10 | cached_query_count: 10)'
+      expected_report_text = '[RailsRequestStats] (AVG view_runtime: 11.6667ms | AVG db_runtime: 11.6667ms | AVG generated_object_count: 11.6667 | query_count: 10 | cached_query_count: 10)'
       expect(subject.report_text).to eq(expected_report_text)
     end
   end
 
   describe '#exit_report_text' do
     it 'returns exit_report_text of request stats' do
-      expected_exit_report_text = '[RailsRequestStats] INDEX:html "/users" (AVG view_runtime: 11.6667ms | AVG db_runtime: 11.6667ms | MIN query_count: 5 | MAX query_count: 20) from 3 requests'
+      expected_exit_report_text = '[RailsRequestStats] INDEX:html "/users" (AVG view_runtime: 11.6667ms | AVG db_runtime: 11.6667ms | AVG generated_object_count: 11.6667 | MIN query_count: 5 | MAX query_count: 20) from 3 requests'
       expect(subject.exit_report_text).to eq(expected_exit_report_text)
     end
   end


### PR DESCRIPTION
By using the `start_processing.action_controller` event we can somewhat
track the generated object count for a request. `GC.start` is used when
we start processing the request so that we have 'fresh' count of the
objects. When the request is processed, we look again at the number of
objects and figure the difference.

Specs were added for this new feature.

README has been updated to include the new tracked feature.
