### PR TITLE
Refactor request stats and finer memory stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ During development have you ever:
 `RailsRequestStats::NotificationSubscribers` when required will subscribe to the `sql.active_record`, `start_processing.action_controller`, and `process_action.action_controller` `ActionSupport::Notifications`.
 
  * The `sql.active_record` event allow us to count each SQL query that passes though ActiveRecord, which we count internally.
- * The `start_processing.action_controller` event allows us to clear iternal counts, as well as perform a `GC.start` and capturing the total number of objects residing in the `ObjectSpace`.
+ * The `start_processing.action_controller` event allows us to clear iternal counts, as well as perform a `GC.start` and capturing the count of objects residing in the `ObjectSpace`.
  * The `process_action.action_controller` event provides us runtime information along with identifying controller action details, we even determine the number of generated objects since the start of processing the action. At this point we are able to synthesis the query information and runtime information and store them internally in running collection of `RailsRequestStats::RequestStats` objects.
 
 **Note** the data collection is tracked and stored in class-level instance variables. Thus this is not threadsafe, as no concurrency mechanisms are used (i.e., mutex). For non-threaded and forking application servers this should be fine.
@@ -49,6 +49,21 @@ Finally when you exit the application's server, you should see a report of all t
 ```
 
 ## Customizing Outputs
+
+### Memory Stats
+By setting the following class variable within in an initializer (`./config/initializers/rails_request_stats.rb`):
+
+```ruby
+RailsRequestStats::Report.print_memory_stats = true
+```
+
+You can see the *generated objects* within the `ObjectSpace` for individual requests:
+
+```
+[RailsRequestStats] (AVG view_runtime: 93.7252ms | AVG db_runtime: 8.66075ms | AVG generated_object_count: 125282 | query_count: 8 | cached_query_count: 0 | generated_objects: {:total_generated_objects=>111878, :object=>921, :class=>35, :module=>0, :float=>0, :string=>49501, :regexp=>1556, :array=>17855, :hash=>2087, :struct=>103, :bignum=>0, :file=>0, :data=>37682, :match=>373, :complex=>0, :node=>1688, :iclass=>0})
+```
+
+### Override Reports
 
 You can manually override the output by monkey-patching in an initializer (`./config/initializers/rails_request_stats.rb`):
 
@@ -81,4 +96,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/kevinj
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/lib/rails_request_stats.rb
+++ b/lib/rails_request_stats.rb
@@ -2,6 +2,9 @@ require 'rails_request_stats/version'
 require 'rails_request_stats/request_stats'
 require 'rails_request_stats/report'
 require 'rails_request_stats/notification_subscribers'
+require 'rails_request_stats/stats/database_query_stats'
+require 'rails_request_stats/stats/object_space_stats'
+require 'rails_request_stats/stats/runtime_stats'
 
 module RailsRequestStats
 end

--- a/lib/rails_request_stats.rb
+++ b/lib/rails_request_stats.rb
@@ -1,10 +1,4 @@
-require 'rails_request_stats/version'
-require 'rails_request_stats/request_stats'
-require 'rails_request_stats/report'
-require 'rails_request_stats/notification_subscribers'
-require 'rails_request_stats/stats/database_query_stats'
-require 'rails_request_stats/stats/object_space_stats'
-require 'rails_request_stats/stats/runtime_stats'
+Dir.glob(File.dirname(__FILE__) + '/**/*.rb') { |file| require file }
 
 module RailsRequestStats
 end

--- a/lib/rails_request_stats/notification_subscribers.rb
+++ b/lib/rails_request_stats/notification_subscribers.rb
@@ -3,11 +3,13 @@ module RailsRequestStats
     SCHEMA_NAME = 'SCHEMA'.freeze
     CACHE_NAME = 'CACHE'.freeze
 
-    attr_reader :query_count,
-                :cached_query_count,
-                :before_object_space,
-                :after_object_space,
-                :requests
+    class << self
+      attr_accessor :query_count,
+                    :cached_query_count,
+                    :before_object_space,
+                    :after_object_space
+                    :requests
+    end
 
     def self.reset_counts
       @query_count = 0

--- a/lib/rails_request_stats/notification_subscribers.rb
+++ b/lib/rails_request_stats/notification_subscribers.rb
@@ -5,15 +5,15 @@ module RailsRequestStats
 
     attr_reader :query_count,
                 :cached_query_count,
-                :before_action_object_count,
-                :generated_object_count,
+                :before_object_space,
+                :after_object_space,
                 :requests
 
     def self.reset_counts
       @query_count = 0
       @cached_query_count = 0
-      @before_action_object_count = 0
-      @generated_object_count = 0
+      @before_object_space = {}
+      @after_object_space = {}
     end
     reset_counts
 
@@ -55,28 +55,29 @@ module RailsRequestStats
       reset_counts
 
       GC.start
-      @before_action_object_count = total_object_count
+      GC.disable
+
+      @before_object_space = ObjectSpace.count_objects(@before_object_space)
     end
 
     def self.handle_process_action_event(event)
-      @generated_object_count = total_object_count - @before_action_object_count
+      @after_object_space = ObjectSpace.count_objects(@after_object_space)
+
+      GC.enable
 
       request_key = { action: event[:action], format: event[:format], method: event[:method], path: event[:path] }
-
       request_stats = @requests[request_key] || RequestStats.new(request_key)
-      request_stats.add_stats(event[:view_runtime], event[:db_runtime], @query_count, @cached_query_count, @generated_object_count)
+      @requests[request_key] = request_stats.tap do |stats|
+        stats.add_database_query_stats(@query_count, @cached_query_count)
+        stats.add_object_space_stats(@before_object_space, @after_object_space)
+        stats.add_runtime_stats(event[:view_runtime], event[:db_runtime])
+      end
 
-      @requests[request_key] = request_stats
-
-      Rails.logger.info { Report.new(request_stats).report_text }
+      print_report(request_stats)
     end
 
-    class << self
-      private
-
-      def total_object_count
-        ObjectSpace.count_objects.select { |k, v| k.to_s.start_with?('T_') }.values.reduce(:+)
-      end
+    def self.print_report(request_stats)
+      Rails.logger.info { Report.new(request_stats).report_text }
     end
   end
 end

--- a/lib/rails_request_stats/report.rb
+++ b/lib/rails_request_stats/report.rb
@@ -2,6 +2,11 @@ module RailsRequestStats
   class Report
     FORMAT_FLAG = '%g'.freeze
 
+    class << self
+      attr_accessor :print_memory_stats
+    end
+    self.print_memory_stats = false
+
     attr_reader :request_stats
 
     def initialize(request_stats)
@@ -14,8 +19,9 @@ module RailsRequestStats
       avg_generated_object_count = "AVG generated_object_count: #{format_number(avg(object_space_stats.generated_object_count_collection))}"
       query_count = "query_count: #{format_number(database_query_stats.query_count_collection.last)}"
       cached_query_count = "cached_query_count: #{format_number(database_query_stats.cached_query_count_collection.last)}"
+      generated_objects = self.class.print_memory_stats ? "generated_objects: #{object_space_stats.last_stats_generated_objects}" : nil
 
-      "[RailsRequestStats] (#{[avg_view_runtime, avg_db_runtime, avg_generated_object_count, query_count, cached_query_count].join(' | ')})"
+      "[RailsRequestStats] (#{[avg_view_runtime, avg_db_runtime, avg_generated_object_count, query_count, cached_query_count, generated_objects].compact.join(' | ')})"
     end
 
     def exit_report_text

--- a/lib/rails_request_stats/request_stats.rb
+++ b/lib/rails_request_stats/request_stats.rb
@@ -5,11 +5,9 @@ module RailsRequestStats
                 :method,
                 :path,
 
-                :view_runtime_collection,
-                :db_runtime_collection,
-                :query_count_collection,
-                :cached_query_count_collection,
-                :generated_object_count_collection
+                :database_query_stats,
+                :object_space_stats,
+                :runtime_stats
 
     def initialize(key)
       @action = key[:action]
@@ -17,19 +15,21 @@ module RailsRequestStats
       @method = key[:method]
       @path = key[:path]
 
-      @view_runtime_collection = []
-      @db_runtime_collection = []
-      @query_count_collection = []
-      @cached_query_count_collection = []
-      @generated_object_count_collection = []
+      @database_query_stats = Stats::DatabaseQueryStats.new
+      @object_space_stats = Stats::ObjectSpaceStats.new
+      @runtime_stats = Stats::RuntimeStats.new
     end
 
-    def add_stats(view_runtime, db_runtime, query_count, cached_query_count, generated_object_count)
-      @view_runtime_collection << view_runtime.to_f
-      @db_runtime_collection << db_runtime.to_f
-      @query_count_collection << query_count
-      @cached_query_count_collection << cached_query_count
-      @generated_object_count_collection << generated_object_count
+    def add_database_query_stats(query_count, cached_query_count)
+      @database_query_stats.add_stats(query_count, cached_query_count)
+    end
+
+    def add_object_space_stats(before_object_space, after_object_space)
+      @object_space_stats.add_stats(before_object_space, after_object_space)
+    end
+
+    def add_runtime_stats(view_runtime, db_runtime)
+      @runtime_stats.add_stats(view_runtime, db_runtime)
     end
   end
 end

--- a/lib/rails_request_stats/stats/database_query_stats.rb
+++ b/lib/rails_request_stats/stats/database_query_stats.rb
@@ -1,0 +1,18 @@
+module RailsRequestStats
+  module Stats
+    class DatabaseQueryStats
+      attr_reader :query_count_collection,
+                  :cached_query_count_collection
+
+      def initialize
+        @query_count_collection = []
+        @cached_query_count_collection = []
+      end
+
+      def add_stats(query_count, cached_query_count)
+        @query_count_collection << query_count
+        @cached_query_count_collection << cached_query_count
+      end
+    end
+  end
+end

--- a/lib/rails_request_stats/stats/object_space_stats.rb
+++ b/lib/rails_request_stats/stats/object_space_stats.rb
@@ -62,6 +62,28 @@ module RailsRequestStats
       def total_object_space_count(object_space)
         object_space.select { |k, v| k.to_s.start_with?('T_') }.values.reduce(:+)
       end
+
+      def last_stats_generated_objects
+        {
+          total_generated_objects: generated_object_count_collection.last,
+          object: object_count_collection.last,
+          class: class_count_collection.last,
+          module: module_count_collection.last,
+          float: float_count_collection.last,
+          string: string_count_collection.last,
+          regexp: regexp_count_collection.last,
+          array: array_count_collection.last,
+          hash: hash_count_collection.last,
+          struct: struct_count_collection.last,
+          bignum: bignum_count_collection.last,
+          file: file_count_collection.last,
+          data: data_count_collection.last,
+          match: match_count_collection.last,
+          complex: complex_count_collection.last,
+          node: node_count_collection.last,
+          iclass: iclass_count_collection.last
+        }
+      end
     end
   end
 end

--- a/lib/rails_request_stats/stats/object_space_stats.rb
+++ b/lib/rails_request_stats/stats/object_space_stats.rb
@@ -1,0 +1,67 @@
+module RailsRequestStats
+  module Stats
+    class ObjectSpaceStats
+      attr_reader :object_count_collection,
+                  :class_count_collection,
+                  :module_count_collection,
+                  :float_count_collection,
+                  :string_count_collection,
+                  :regexp_count_collection,
+                  :array_count_collection,
+                  :hash_count_collection,
+                  :struct_count_collection,
+                  :bignum_count_collection,
+                  :file_count_collection,
+                  :data_count_collection,
+                  :match_count_collection,
+                  :complex_count_collection,
+                  :node_count_collection,
+                  :iclass_count_collection,
+                  :generated_object_count_collection
+
+      def initialize
+        @object_count_collection = []
+        @class_count_collection = []
+        @module_count_collection = []
+        @float_count_collection = []
+        @string_count_collection = []
+        @regexp_count_collection = []
+        @array_count_collection = []
+        @hash_count_collection = []
+        @struct_count_collection = []
+        @bignum_count_collection = []
+        @file_count_collection = []
+        @data_count_collection = []
+        @match_count_collection = []
+        @complex_count_collection = []
+        @node_count_collection = []
+        @iclass_count_collection = []
+        @generated_object_count_collection = []
+      end
+
+      def add_stats(before_object_space, after_object_space)
+        @object_count_collection << after_object_space[:T_OBJECT] - before_object_space[:T_OBJECT]
+        @class_count_collection << after_object_space[:T_CLASS] - before_object_space[:T_CLASS]
+        @module_count_collection << after_object_space[:T_MODULE] - before_object_space[:T_MODULE]
+        @float_count_collection << after_object_space[:T_FLOAT] - before_object_space[:T_FLOAT]
+        @string_count_collection << after_object_space[:T_STRING] - before_object_space[:T_STRING]
+        @regexp_count_collection << after_object_space[:T_REGEXP] - before_object_space[:T_REGEXP]
+        @array_count_collection << after_object_space[:T_ARRAY] - before_object_space[:T_ARRAY]
+        @hash_count_collection << after_object_space[:T_HASH] - before_object_space[:T_HASH]
+        @struct_count_collection << after_object_space[:T_STRUCT] - before_object_space[:T_STRUCT]
+        @bignum_count_collection << after_object_space[:T_BIGNUM] - before_object_space[:T_BIGNUM]
+        @file_count_collection << after_object_space[:T_FILE] - before_object_space[:T_FILE]
+        @data_count_collection << after_object_space[:T_DATA] - before_object_space[:T_DATA]
+        @match_count_collection << after_object_space[:T_MATCH] - before_object_space[:T_MATCH]
+        @complex_count_collection << after_object_space[:T_COMPLEX] - before_object_space[:T_COMPLEX]
+        @node_count_collection << after_object_space[:T_NODE] - before_object_space[:T_NODE]
+        @iclass_count_collection << after_object_space[:T_ICLASS] - before_object_space[:T_ICLASS]
+        @generated_object_count_collection << total_object_space_count(after_object_space) - total_object_space_count(before_object_space)
+      end
+
+      def total_object_space_count(object_space)
+        object_space.select { |k, v| k.to_s.start_with?('T_') }.values.reduce(:+)
+      end
+    end
+  end
+end

--- a/lib/rails_request_stats/stats/runtime_stats.rb
+++ b/lib/rails_request_stats/stats/runtime_stats.rb
@@ -1,0 +1,18 @@
+module RailsRequestStats
+  module Stats
+    class RuntimeStats
+      attr_reader :view_runtime_collection,
+                  :db_runtime_collection
+
+      def initialize
+        @view_runtime_collection = []
+        @db_runtime_collection = []
+      end
+
+      def add_stats(view_runtime, db_runtime)
+        @view_runtime_collection << view_runtime
+        @db_runtime_collection << db_runtime
+      end
+    end
+  end
+end

--- a/spec/rails_request_stats/report_spec.rb
+++ b/spec/rails_request_stats/report_spec.rb
@@ -10,20 +10,39 @@ describe RailsRequestStats::Report do
     RailsRequestStats::RequestStats.new(action: action, format: format, method: method, path: path)
   end
 
-  let(:categories) { [:view_runtime, :db_runtime, :query_count, :cached_query_count] }
-  let(:stat_values) { [5, 20, 10] }
-
   subject { described_class.new(request_stats) }
 
   before do
-    stat_values.each do |value|
-      request_stats.add_stats(value, value, value, value, value)
-    end
+    collection = [10, 5, 20]
+
+    allow(request_stats.runtime_stats).to receive(:view_runtime_collection) { collection }
+    allow(request_stats.runtime_stats).to receive(:db_runtime_collection) { collection }
+
+    allow(request_stats.database_query_stats).to receive(:query_count_collection) { collection }
+    allow(request_stats.database_query_stats).to receive(:cached_query_count_collection) { collection }
+
+    allow(request_stats.object_space_stats).to receive(:object_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:class_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:module_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:float_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:string_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:regexp_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:array_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:hash_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:struct_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:bignum_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:file_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:data_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:match_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:complex_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:node_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:iclass_count_collection) { collection }
+    allow(request_stats.object_space_stats).to receive(:generated_object_count_collection) { collection }
   end
 
   describe '#report_text' do
     it 'returns report_text of last added stats' do
-      expected_report_text = '[RailsRequestStats] (AVG view_runtime: 11.6667ms | AVG db_runtime: 11.6667ms | AVG generated_object_count: 11.6667 | query_count: 10 | cached_query_count: 10)'
+      expected_report_text = '[RailsRequestStats] (AVG view_runtime: 11.6667ms | AVG db_runtime: 11.6667ms | AVG generated_object_count: 11.6667 | query_count: 20 | cached_query_count: 20)'
       expect(subject.report_text).to eq(expected_report_text)
     end
   end
@@ -35,51 +54,19 @@ describe RailsRequestStats::Report do
     end
   end
 
-  describe '#min_stat' do
-    it 'returns min stat value for specified category' do
-      categories.each do |category|
-        expect(subject.min_stat(category)).to eq(stat_values.min)
-      end
+  describe '#total' do
+    it 'returns total stat for a collection' do
+      collection = [10, 20, 30]
+      expect_result = 60
+      expect(subject.total(collection)).to eq(expect_result)
     end
   end
 
-  describe '#max_stat' do
-    it 'returns max stat value for specified category' do
-      categories.each do |category|
-        expect(subject.max_stat(category)).to eq(stat_values.max)
-      end
-    end
-  end
-
-  describe '#total_stat' do
-    it 'returns total stat value for specified category' do
-      categories.each do |category|
-        expect(subject.total_stat(category)).to eq(stat_values.reduce(:+))
-      end
-    end
-  end
-
-  describe '#count_stat' do
-    it 'returns count stat value for specified category' do
-      categories.each do |category|
-        expect(subject.count_stat(category)).to eq(stat_values.size)
-      end
-    end
-  end
-
-  describe '#last_stat' do
-    it 'returns last stat value for specified category' do
-      categories.each do |category|
-        expect(subject.last_stat(category)).to eq(stat_values.last)
-      end
-    end
-  end
-
-  describe '#avg_stat' do
+  describe '#avg' do
     it 'returns avg stat value for specified category' do
-      categories.each do |category|
-        expect(subject.avg_stat(category)).to eq(stat_values.reduce(:+).to_f / stat_values.size)
-      end
+      collection = [10, 20, 30]
+      expect_result = 60/collection.size
+      expect(subject.avg(collection)).to eq(expect_result)
     end
   end
 end

--- a/spec/rails_request_stats/stats/database_query_stats_spec.rb
+++ b/spec/rails_request_stats/stats/database_query_stats_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe RailsRequestStats::Stats::DatabaseQueryStats do
+  describe '#add_stats' do
+    it 'stores values' do
+      query_count = 10
+      cached_query_count = 20
+
+      subject.add_stats(query_count, cached_query_count)
+
+      expect(subject.query_count_collection).to eq([query_count])
+      expect(subject.cached_query_count_collection).to eq([cached_query_count])
+    end
+  end
+end

--- a/spec/rails_request_stats/stats/object_space_stats_spec.rb
+++ b/spec/rails_request_stats/stats/object_space_stats_spec.rb
@@ -92,4 +92,48 @@ describe RailsRequestStats::Stats::ObjectSpaceStats do
       expect(subject.total_object_space_count(object_space)).to eq(160000)
     end
   end
+
+  describe '#last_stats_generated_objects' do
+    it 'returns hash of last stats generated objects' do
+      expected_hash = {
+        total_generated_objects: 160000,
+        object: 10000,
+        class: 10000,
+        module: 10000,
+        float: 10000,
+        string: 10000,
+        regexp: 10000,
+        array: 10000,
+        hash: 10000,
+        struct: 10000,
+        bignum: 10000,
+        file: 10000,
+        data: 10000,
+        match: 10000,
+        complex: 10000,
+        node: 10000,
+        iclass: 10000
+      }
+
+      allow(subject).to receive(:generated_object_count_collection) { [160000] }
+      allow(subject).to receive(:object_count_collection) { [10000] }
+      allow(subject).to receive(:class_count_collection) { [10000] }
+      allow(subject).to receive(:module_count_collection) { [10000] }
+      allow(subject).to receive(:float_count_collection) { [10000] }
+      allow(subject).to receive(:string_count_collection) { [10000] }
+      allow(subject).to receive(:regexp_count_collection) { [10000] }
+      allow(subject).to receive(:array_count_collection) { [10000] }
+      allow(subject).to receive(:hash_count_collection) { [10000] }
+      allow(subject).to receive(:struct_count_collection) { [10000] }
+      allow(subject).to receive(:bignum_count_collection) { [10000] }
+      allow(subject).to receive(:file_count_collection) { [10000] }
+      allow(subject).to receive(:data_count_collection) { [10000] }
+      allow(subject).to receive(:match_count_collection) { [10000] }
+      allow(subject).to receive(:complex_count_collection) { [10000] }
+      allow(subject).to receive(:node_count_collection) { [10000] }
+      allow(subject).to receive(:iclass_count_collection) { [10000] }
+
+      expect(subject.last_stats_generated_objects).to eq(expected_hash)
+    end
+  end
 end

--- a/spec/rails_request_stats/stats/object_space_stats_spec.rb
+++ b/spec/rails_request_stats/stats/object_space_stats_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe RailsRequestStats::Stats::ObjectSpaceStats do
+  describe '#add_stats' do
+    it 'stores values' do
+      before_object_space = {
+        TOTAL: 210000,
+        FREE: 50000,
+        T_OBJECT: 10000,
+        T_CLASS: 10000,
+        T_MODULE: 10000,
+        T_FLOAT: 10000,
+        T_STRING: 10000,
+        T_REGEXP: 10000,
+        T_ARRAY: 10000,
+        T_HASH: 10000,
+        T_STRUCT: 10000,
+        T_BIGNUM: 10000,
+        T_FILE: 10000,
+        T_DATA: 10000,
+        T_MATCH: 10000,
+        T_COMPLEX: 10000,
+        T_NODE: 10000,
+        T_ICLASS: 10000
+      }
+
+      after_object_space = {
+        TOTAL: 420000,
+        FREE: 100000,
+        T_OBJECT: 20000,
+        T_CLASS: 20000,
+        T_MODULE: 20000,
+        T_FLOAT: 20000,
+        T_STRING: 20000,
+        T_REGEXP: 20000,
+        T_ARRAY: 20000,
+        T_HASH: 20000,
+        T_STRUCT: 20000,
+        T_BIGNUM: 20000,
+        T_FILE: 20000,
+        T_DATA: 20000,
+        T_MATCH: 20000,
+        T_COMPLEX: 20000,
+        T_NODE: 20000,
+        T_ICLASS: 20000
+      }
+
+      subject.add_stats(before_object_space, after_object_space)
+
+      expect(subject.object_count_collection).to eq([10000])
+      expect(subject.class_count_collection).to eq([10000])
+      expect(subject.module_count_collection).to eq([10000])
+      expect(subject.float_count_collection).to eq([10000])
+      expect(subject.string_count_collection).to eq([10000])
+      expect(subject.regexp_count_collection).to eq([10000])
+      expect(subject.array_count_collection).to eq([10000])
+      expect(subject.hash_count_collection).to eq([10000])
+      expect(subject.struct_count_collection).to eq([10000])
+      expect(subject.bignum_count_collection).to eq([10000])
+      expect(subject.file_count_collection).to eq([10000])
+      expect(subject.data_count_collection).to eq([10000])
+      expect(subject.match_count_collection).to eq([10000])
+      expect(subject.complex_count_collection).to eq([10000])
+      expect(subject.node_count_collection).to eq([10000])
+      expect(subject.iclass_count_collection).to eq([10000])
+      expect(subject.generated_object_count_collection).to eq([160000])
+    end
+  end
+
+  describe '#total_object_space_count' do
+    it 'calculates correct value' do
+      object_space = {
+        TOTAL: 210000,
+        FREE: 50000,
+        T_OBJECT: 10000,
+        T_CLASS: 10000,
+        T_MODULE: 10000,
+        T_FLOAT: 10000,
+        T_STRING: 10000,
+        T_REGEXP: 10000,
+        T_ARRAY: 10000,
+        T_HASH: 10000,
+        T_STRUCT: 10000,
+        T_BIGNUM: 10000,
+        T_FILE: 10000,
+        T_DATA: 10000,
+        T_MATCH: 10000,
+        T_COMPLEX: 10000,
+        T_NODE: 10000,
+        T_ICLASS: 10000
+      }
+      expect(subject.total_object_space_count(object_space)).to eq(160000)
+    end
+  end
+end

--- a/spec/rails_request_stats/stats/runtime_stats_spec.rb
+++ b/spec/rails_request_stats/stats/runtime_stats_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe RailsRequestStats::Stats::RuntimeStats do
+  describe '#add_stats' do
+    it 'stores values' do
+      view_runtime = 10.10
+      db_runtime = 20.20
+
+      subject.add_stats(view_runtime, db_runtime)
+
+      expect(subject.view_runtime_collection).to eq([view_runtime])
+      expect(subject.db_runtime_collection).to eq([db_runtime])
+    end
+  end
+end


### PR DESCRIPTION
As there were various 'types' of stats being stored, it made more sense to break up the RequestStats class into a basic class which holds individual stats objects (RuntimeStats, DatabaseQueryStats, and ObjectSpaceStats).

Specs had to be complete reworked to accommodate for the large refactoring of how stats are stored.

ObjectSpaceStats now not only stores the total generated object counts, but also the individual object counts (i.e., classes, strings, modules, etc...). These can be accessed from the ObjectSpaceStats objects.

A class variable is used to indicate if memory stats should be included in the individual request stats report. If not it is omitted.
