### PR TITLE
Add ability to track read/hits to the Rails cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: ruby
 rvm:
   - 2.2.3
 before_install: gem install bundler -v 1.10.6
+after_success:
+  - bundle exec codeclimate-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in rails_request_stats.gemspec
-gemspec
+group :test do
+  gem 'simplecov'
+  gem 'codeclimate-test-reporter', '~> 1.0.0'
+end
 
-gem 'codeclimate-test-reporter', group: :test, require: nil
+gemspec

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ During development have you ever:
 `RailsRequestStats::NotificationSubscribers` when required will subscribe to the `sql.active_record`, `start_processing.action_controller`, and `process_action.action_controller` `ActionSupport::Notifications`.
 
  * The `sql.active_record` event allow us to count each SQL query that passes though ActiveRecord, which we count internally.
+ * The `cache_read.active_support` event allows us to count each read and hit to the Rails cache.
+ * The `cache_fetch_hit.active_support` event allows us to count the cache hits to the Rails cache when using *fetch*.
  * The `start_processing.action_controller` event allows us to clear iternal counts, as well as perform a `GC.start` and capturing the count of objects residing in the `ObjectSpace`.
  * The `process_action.action_controller` event provides us runtime information along with identifying controller action details, we even determine the number of generated objects since the start of processing the action. At this point we are able to synthesis the query information and runtime information and store them internally in running collection of `RailsRequestStats::RequestStats` objects.
 
@@ -37,10 +39,10 @@ gem 'rails_request_stats', group: :development
 Within the console ./log/development.log you should start seeing the following statement appearing at the end of processing a request:
 
 ```
-[RailsRequestStats] (AVG view_runtime: 163.655ms | AVG db_runtime: 15.465ms | AVG generated_object_count: 14523 | query_count: 9 | cached_query_count: 0)
+[RailsRequestStats] (AVG view_runtime: 163.655ms | AVG db_runtime: 15.465ms | AVG generated_object_count: 14523 | query_count: 9 | cached_query_count: 0 | cache_read_count: 3 | cache_hit_count: 3)
 ```
 
-Finally when you exit the application's server, you should see a report of all the data captured:
+Finally when you exit the application's server, you should see a summary report of all the data captured:
 
 ```
 [RailsRequestStats] INDEX:html "/users" (AVG view_runtime: 128.492ms | AVG db_runtime: 9.186ms | AVG generated_object_count: 25529 | MIN query_count: 8 | MAX query_count: 9) from 4 requests
@@ -60,7 +62,7 @@ RailsRequestStats::Report.print_memory_stats = true
 You can see the *generated objects* within the `ObjectSpace` for individual requests:
 
 ```
-[RailsRequestStats] (AVG view_runtime: 93.7252ms | AVG db_runtime: 8.66075ms | AVG generated_object_count: 125282 | query_count: 8 | cached_query_count: 0 | generated_objects: {:total_generated_objects=>111878, :object=>921, :class=>35, :module=>0, :float=>0, :string=>49501, :regexp=>1556, :array=>17855, :hash=>2087, :struct=>103, :bignum=>0, :file=>0, :data=>37682, :match=>373, :complex=>0, :node=>1688, :iclass=>0})
+[RailsRequestStats] (AVG view_runtime: 93.7252ms | AVG db_runtime: 8.66075ms | AVG generated_object_count: 125282 | query_count: 8 | cached_query_count: 0 | cache_read_count: 3 | cache_hit_count: 3 | generated_objects: {:total_generated_objects=>111878, :object=>921, :class=>35, :module=>0, :float=>0, :string=>49501, :regexp=>1556, :array=>17855, :hash=>2087, :struct=>103, :bignum=>0, :file=>0, :data=>37682, :match=>373, :complex=>0, :node=>1688, :iclass=>0})
 ```
 
 ### Override Reports

--- a/lib/rails_request_stats/report.rb
+++ b/lib/rails_request_stats/report.rb
@@ -19,9 +19,11 @@ module RailsRequestStats
       avg_generated_object_count = "AVG generated_object_count: #{format_number(avg(object_space_stats.generated_object_count_collection))}"
       query_count = "query_count: #{format_number(database_query_stats.query_count_collection.last)}"
       cached_query_count = "cached_query_count: #{format_number(database_query_stats.cached_query_count_collection.last)}"
+      cache_read_count = "cache_read_count: #{format_number(cache_stats.cache_read_count_collection.last)}"
+      cache_hit_count = "cache_hit_count: #{format_number(cache_stats.cache_hit_count_collection.last)}"
       generated_objects = self.class.print_memory_stats ? "generated_objects: #{object_space_stats.last_stats_generated_objects}" : nil
 
-      "[RailsRequestStats] (#{[avg_view_runtime, avg_db_runtime, avg_generated_object_count, query_count, cached_query_count, generated_objects].compact.join(' | ')})"
+      "[RailsRequestStats] (#{[avg_view_runtime, avg_db_runtime, avg_generated_object_count, query_count, cached_query_count, cache_read_count, cache_hit_count, generated_objects].compact.join(' | ')})"
     end
 
     def exit_report_text
@@ -60,6 +62,10 @@ module RailsRequestStats
 
     def runtime_stats
       @runtime_stats ||= @request_stats.runtime_stats
+    end
+
+    def cache_stats
+      @cache_stats ||= @request_stats.cache_stats
     end
   end
 end

--- a/lib/rails_request_stats/request_stats.rb
+++ b/lib/rails_request_stats/request_stats.rb
@@ -7,7 +7,8 @@ module RailsRequestStats
 
                 :database_query_stats,
                 :object_space_stats,
-                :runtime_stats
+                :runtime_stats,
+                :cache_stats
 
     def initialize(key)
       @action = key[:action]
@@ -18,6 +19,7 @@ module RailsRequestStats
       @database_query_stats = Stats::DatabaseQueryStats.new
       @object_space_stats = Stats::ObjectSpaceStats.new
       @runtime_stats = Stats::RuntimeStats.new
+      @cache_stats = Stats::CacheStats.new
     end
 
     def add_database_query_stats(query_count, cached_query_count)
@@ -30,6 +32,10 @@ module RailsRequestStats
 
     def add_runtime_stats(view_runtime, db_runtime)
       @runtime_stats.add_stats(view_runtime, db_runtime)
+    end
+
+    def add_cache_stats(cache_read_count, cache_hit_count)
+      @cache_stats.add_stats(cache_read_count, cache_hit_count)
     end
   end
 end

--- a/lib/rails_request_stats/stats/cache_stats.rb
+++ b/lib/rails_request_stats/stats/cache_stats.rb
@@ -1,0 +1,18 @@
+module RailsRequestStats
+  module Stats
+    class CacheStats
+      attr_reader :cache_read_count_collection
+      attr_reader :cache_hit_count_collection
+
+      def initialize
+        @cache_read_count_collection = []
+        @cache_hit_count_collection = []
+      end
+
+      def add_stats(cache_read_count, cache_hit_count)
+        @cache_read_count_collection << cache_read_count
+        @cache_hit_count_collection << cache_hit_count
+      end
+    end
+  end
+end

--- a/spec/rails_request_stats/notification_subscribers_spec.rb
+++ b/spec/rails_request_stats/notification_subscribers_spec.rb
@@ -139,6 +139,49 @@ describe RailsRequestStats::NotificationSubscribers do
     end
   end
 
+  describe '.handle_cache_read_event' do
+    context 'cache hit' do
+      it 'processes cache read event' do
+        event = {
+          key: 'awesome/event_serializer/1da77373824117ede4eb3359f1a56467/attributes',
+          super_operation: :fetch,
+          hit: true
+        }
+
+        described_class.handle_cache_read_event(event)
+
+        expect(described_class.instance_variable_get('@cache_read_count')).to eq(1)
+        expect(described_class.instance_variable_get('@cache_hit_count')).to eq(1)
+      end
+    end
+
+    context 'no cache hit' do
+      it 'processes cache read event' do
+        event = {
+          key: 'awesome/event_serializer/1da77373824117ede4eb3359f1a56467/attributes',
+          super_operation: :fetch
+        }
+
+        described_class.handle_cache_read_event(event)
+
+        expect(described_class.instance_variable_get('@cache_read_count')).to eq(1)
+        expect(described_class.instance_variable_get('@cache_hit_count')).to eq(0)
+      end
+    end
+  end
+
+  describe '.handle_cache_fetch_hit_event' do
+    context 'cache fetch hit' do
+      it 'processes cache fetch hit event' do
+        event = { key: 'awesome/event_serializer/1da77373824117ede4eb3359f1a56467/attributes' }
+
+        described_class.handle_cache_fetch_hit_event(event)
+
+        expect(described_class.instance_variable_get('@cache_hit_count')).to eq(1)
+      end
+    end
+  end
+
   describe '.handle_process_action_event' do
     it 'processes controller action event' do
       action = 'index'

--- a/spec/rails_request_stats/report_spec.rb
+++ b/spec/rails_request_stats/report_spec.rb
@@ -38,11 +38,14 @@ describe RailsRequestStats::Report do
     allow(request_stats.object_space_stats).to receive(:node_count_collection) { collection }
     allow(request_stats.object_space_stats).to receive(:iclass_count_collection) { collection }
     allow(request_stats.object_space_stats).to receive(:generated_object_count_collection) { collection }
+
+    allow(request_stats.cache_stats).to receive(:cache_read_count_collection) { collection }
+    allow(request_stats.cache_stats).to receive(:cache_hit_count_collection) { collection }
   end
 
   describe '#report_text' do
     it 'returns report_text of last added stats' do
-      expected_report_text = '[RailsRequestStats] (AVG view_runtime: 11.6667ms | AVG db_runtime: 11.6667ms | AVG generated_object_count: 11.6667 | query_count: 20 | cached_query_count: 20)'
+      expected_report_text = '[RailsRequestStats] (AVG view_runtime: 11.6667ms | AVG db_runtime: 11.6667ms | AVG generated_object_count: 11.6667 | query_count: 20 | cached_query_count: 20 | cache_read_count: 20 | cache_hit_count: 20)'
       expect(subject.report_text).to eq(expected_report_text)
     end
   end
@@ -65,7 +68,7 @@ describe RailsRequestStats::Report do
   describe '#avg' do
     it 'returns avg stat value for specified category' do
       collection = [10, 20, 30]
-      expect_result = 60/collection.size
+      expect_result = 60 / collection.size
       expect(subject.avg(collection)).to eq(expect_result)
     end
   end

--- a/spec/rails_request_stats/stats/cache_stats_spec.rb
+++ b/spec/rails_request_stats/stats/cache_stats_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe RailsRequestStats::Stats::CacheStats do
+  describe '#add_stats' do
+    it 'stores values' do
+      cache_read_count = 10
+      cache_hit_count = 5
+
+      subject.add_stats(cache_read_count, cache_hit_count)
+
+      expect(subject.cache_read_count_collection).to eq([cache_read_count])
+      expect(subject.cache_hit_count_collection).to eq([cache_hit_count])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rails'


### PR DESCRIPTION
Should close out #1.

New PR was made as there was substantial changes made on master.

This PR adds the ability to track cache reads/hits against the Rails cache.